### PR TITLE
refactor: 검색어없음 랜더조건 수정, Search useEffect 로직 리팩토링, 에러 핸들링 수정

### DIFF
--- a/src/components/Recommendations.tsx
+++ b/src/components/Recommendations.tsx
@@ -27,9 +27,7 @@ function Recommendations({
           setInputValue={setInputValue}
         />
       ))}
-      {inputValue.length > 0 && searchResults.length <= 0 && (
-        <li>검색어 없음</li>
-      )}
+      {!isLoading && !searchResults.length && <li>검색어 없음</li>}
       {isLoading && inputValue.length > 0 && <Spinner />}
     </ul>
   );

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -11,21 +11,15 @@ function Search() {
 
   useEffect(() => {
     setIsLoading(true);
-    const fetchSearchResults = async () => {
-      const { state, data } = await getSearchResults(inputValue);
-      if (state === 'success') setSearchResults(data);
-      setIsLoading(false);
-    };
-
-    if (inputValue) {
-      fetchSearchResults();
-      return;
-    }
-
-    setSearchResults([]);
+    (async () => {
+      setSearchResults([]);
+      if (inputValue.length > 0) {
+        const data = await getSearchResults(inputValue);
+        setSearchResults(data);
+        setIsLoading(false);
+      }
+    })();
   }, [inputValue]);
-
-  console.log('랜더링');
 
   return (
     <section>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -14,7 +14,7 @@ function Search() {
     (async () => {
       setSearchResults([]);
       if (inputValue.length > 0) {
-        const data = await getSearchResults(inputValue);
+        const { data } = await getSearchResults(inputValue);
         setSearchResults(data);
         setIsLoading(false);
       }

--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -1,17 +1,16 @@
-import axios from "axios";
+import axios from 'axios';
 
 async function getSearchResults(input: string) {
-  console.info("calling api");
+  console.info('calling api');
   try {
     const response = await axios.get(
       `${process.env.REACT_APP_API_ADDRESS}?q=${input}`
     );
-    return { state: "success", data: response.data };
+    return response.data;
   } catch (e) {
-    if (e instanceof Error) {
+    if (e instanceof Error)
       alert(`통신에 실패했습니다. 다시 시도해주세요: ${e.message}`);
-    }
-    return { state: "fail", data: null };
+    return null;
   }
 }
 

--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -6,11 +6,12 @@ async function getSearchResults(input: string) {
     const response = await axios.get(
       `${process.env.REACT_APP_API_ADDRESS}?q=${input}`
     );
-    return response.data;
+    return { state: 'success', data: response.data };
   } catch (e) {
-    if (e instanceof Error)
+    if (e instanceof Error) {
       alert(`통신에 실패했습니다. 다시 시도해주세요: ${e.message}`);
-    return null;
+    }
+    return { state: 'fail', data: [] };
   }
 }
 


### PR DESCRIPTION
1. Search 컴포넌트에서 기존 채림님이 작성하신  useEffect문에서, 데이터를 가져오는 getSearchResult라는 fetcher 함수 자체가 데이터를 가져오는 명확한 의미를 가지는데, 다시 한번 fetchSearchResult라는 이름의 함수를 만들필요가 없다고 생각했습니다. 
그래서 익명함수로 바꿔보았고, 더불어 인풋값 지우는 if문을 로직도 리팩토링 해봤습니다.

2. getSearchResults api 함수에서 try catch로 에러핸들링을 하고있기 때문에 사용하는 useEffect에서 다시한번 state로 조건문을 써서 에러 핸들링하는게 중복된다고 보여서 바꿔봤습니다. 

3. Recomendations 컴포넌트에서 영민님께 부탁드렸던 로딩스피너 랜더링 조건에 관해 이전에 제가 수정했던 점이 반영되었습니다. 

