### PR TITLE
fix: 일치하는 추천어 볼드 처리가 한번만 되는 문제

### DIFF
--- a/src/components/RecommendationItem.tsx
+++ b/src/components/RecommendationItem.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Dispatch, SetStateAction } from 'react';
 
 interface Props {
@@ -13,25 +14,16 @@ function RecommendationItem({
   setInputValue,
   isSelected,
 }: Props) {
-  const firstIndex = sick
-    .split('')
-    .findIndex(letter => letter === inputValue[0]);
-  const beforeLetters = sick.slice(0, firstIndex).trim();
-  const restLetters = sick.slice(firstIndex + inputValue.length).trim();
-
-  return (
-    <li
-      role="presentation"
-      onClick={() => setInputValue(sick)}
-      className={`flex py-1.5 items-center cursor-pointer ${
-        isSelected && 'bg-blue-200'
-      }`}
-    >
-      {beforeLetters}
-      <strong>{inputValue}</strong>
-      {restLetters}
-    </li>
-  );
+  const fullWord = sick
+    .split(new RegExp(`(${inputValue})`, 'gi'))
+    .map(splittedParts =>
+      splittedParts.toLowerCase() === inputValue.toLowerCase() ? (
+        <strong>{inputValue}</strong>
+      ) : (
+        splittedParts
+      ),
+    );
+  return <li>{fullWord}</li>;
 }
 
 export default RecommendationItem;

--- a/src/components/RecommendationItem.tsx
+++ b/src/components/RecommendationItem.tsx
@@ -17,7 +17,7 @@ function RecommendationItem({
     .split(new RegExp(`(${inputValue})`, 'gi'))
     .map(splittedParts =>
       splittedParts.toLowerCase() === inputValue.toLowerCase() ? (
-        <strong>{inputValue}</strong>
+        <strong key={Math.random()}>{inputValue}</strong>
       ) : (
         splittedParts
       ),

--- a/src/components/RecommendationItem.tsx
+++ b/src/components/RecommendationItem.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Dispatch, SetStateAction } from 'react';
 
 interface Props {
@@ -23,7 +22,17 @@ function RecommendationItem({
         splittedParts
       ),
     );
-  return <li>{fullWord}</li>;
+  return (
+    <li
+      role="presentation"
+      onClick={() => setInputValue(sick)}
+      className={`flex py-1.5 items-center cursor-pointer ${
+        isSelected && 'bg-blue-200'
+      }`}
+    >
+      {fullWord}
+    </li>
+  );
 }
 
 export default RecommendationItem;

--- a/src/hooks/useSelectedIndex.ts
+++ b/src/hooks/useSelectedIndex.ts
@@ -20,7 +20,7 @@ export default function useSelectedIndex(
 
   useEffect(() => {
     setSelectedIndex(-1);
-  }, list);
+  }, [list]);
 
   return [selectedIndex, increaseSelectedIndex, decreaseSelectedIndex];
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,6 @@ const root = ReactDOM.createRoot(
 );
 root.render(
   <React.StrictMode>
-    <App />,
+    <App />
   </React.StrictMode>,
 );


### PR DESCRIPTION
검색어와 추천어가 일치하는 부분이 여러번 나왔을 때 한번만 볼드 처리되는 문제를 수정했습니다.

정규식의 g 플래그를 사용하여 일치하는 부분을 기준으로 나눈 뒤 일치하는 부분만 <strong> 태그에 감싸고 나머지는 그대로 리턴했습니다.