### PR TITLE
fix: 입력창에서 focus 벗어나면 선택인덱스 초기화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20135,7 +20135,9 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "requires": {}
+      "requires": {
+        "ajv": "^8.0.0"
+      }
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -28347,6 +28349,7 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
+        "postcss": "^8.4.18",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -13,7 +13,7 @@ function Search() {
   const [isLoading, setIsLoading] = useState(false);
 
   const maxRecommendation = 7;
-  const [selectedIndex, increaseSelectedIndex, decreaseSelectedIndex] =
+  const [selectedIndex, increaseSelectedIndex, decreaseSelectedIndex, clearSelectedIndex] =
     useSelectedIndex(searchResults, maxRecommendation);
 
   const debouncedValue = useDebounce(inputValue);
@@ -40,6 +40,7 @@ function Search() {
         inputValue={inputValue}
         setInputValue={setInputValue}
         onArrowKeyDown={[decreaseSelectedIndex, increaseSelectedIndex]}
+        onBlur={clearSelectedIndex}
       />
       <Recommendations
         inputValue={inputValue}

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -5,12 +5,14 @@ interface Props {
   inputValue: string;
   setInputValue: Dispatch<SetStateAction<string>>;
   onArrowKeyDown?: [() => void, () => void];
+  onBlur?: () => void
 }
 
 function SearchInput({
   inputValue,
   setInputValue,
   onArrowKeyDown = [() => {}, () => {}],
+  onBlur = () => {}
 }: Props) {
   const [onArrowUp, onArrowDown] = onArrowKeyDown;
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -40,6 +42,7 @@ function SearchInput({
           value={inputValue}
           onChange={e => setInputValue(e.target.value)}
           onKeyDown={onKeyDown}
+          onBlur={onBlur}
         />
         <button
           className="peer-valid/input:visible invisible"

--- a/src/hooks/useSelectedIndex.ts
+++ b/src/hooks/useSelectedIndex.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 export default function useSelectedIndex(
   list: object[],
   maxIndex: number,
-): [number, () => void, () => void] {
+): [number, () => void, () => void, () => void] {
   const [selectedIndex, setSelectedIndex] = useState(-1);
 
   const increaseSelectedIndex = () => {
@@ -22,5 +22,9 @@ export default function useSelectedIndex(
     setSelectedIndex(-1);
   }, [list]);
 
-  return [selectedIndex, increaseSelectedIndex, decreaseSelectedIndex];
+  const clearSelectedIndex = () => {
+    setSelectedIndex(-1);
+  }
+
+  return [selectedIndex, increaseSelectedIndex, decreaseSelectedIndex, clearSelectedIndex];
 }


### PR DESCRIPTION
- useSelectedIndex 훅에서 clearSelectedIndex (인덱스 초기화 함수) 반환
- Search 컴포넌트에서 SearchInput 으로 전달
- SearchInput 의 input에 onBlur 이벤트로 달아줌